### PR TITLE
Corrected license declaration in project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,6 @@
 (defproject faker "0.2.2"
   :description "Generate fake data, port of ruby faker"
   :url "http://github.com/paraseba/faker"
-  :license "Eclipse Public License 1.0"
+  :license {:name "Eclipse Public License 1.0"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.2.0"]])


### PR DESCRIPTION
The license declaration in the project.cjl didn't follow the leiningen format and was being ignored. Corrected that.
