### PR TITLE
Adapt namespaces to be clojurescript compilable

### DIFF
--- a/src/faker/address.cljc
+++ b/src/faker/address.cljc
@@ -1,7 +1,7 @@
 (ns faker.address
   "Create fake address data."
-  (:use faker.address-data)
   (:require [faker.name :as na]
+            [faker.address-data :as ad]
             [clojure.string :as string]))
 
 
@@ -19,27 +19,27 @@
 (defn us-state
   "Returns a random USA state."
   []
-  (rand-nth us-states))
+  (rand-nth ad/us-states))
 
 (defn us-state-abbr
   "Returns a random USA state abbreviation."
   []
-  (rand-nth us-state-abbrs))
+  (rand-nth ad/us-state-abbrs))
 
 (defn city-prefix
   "Returns a random city prefix, like North or South."
   []
-  (rand-nth city-prefixes))
+  (rand-nth ad/city-prefixes))
 
 (defn city-suffix
   "Returns a random city suffix, like town or land."
   []
-  (rand-nth city-suffixes))
+  (rand-nth ad/city-suffixes))
 
 (defn street-suffix
   "Returns a random street suffix, like Avenue or Bridge."
   []
-  (rand-nth street-suffixes))
+  (rand-nth ad/street-suffixes))
 
 (def ^{:private true} city-formats
   [#(format "%s %s%s" (city-prefix) (na/first-name) (city-suffix))
@@ -79,12 +79,12 @@
 (defn uk-county
   "Return a random UK county."
   []
-  (rand-nth uk-counties))
+  (rand-nth ad/uk-counties))
 
 (defn uk-country
   "Return a random UK country."
   []
-  (rand-nth uk-countries))
+  (rand-nth ad/uk-countries))
 
 (def ^{:private true} alphabet (seq "abcdefghijklmnopqrstuvwxyz"))
 

--- a/src/faker/company.cljc
+++ b/src/faker/company.cljc
@@ -1,14 +1,13 @@
 (ns faker.company
   "Create fake company data"
-  (:use
-     [clojure.string :only (join)]
-     faker.company-data)
-  (:require [faker.name :as fkname]))
+  (:require [faker.name :as fkname]
+            [clojure.string :refer [join]]
+            [faker.company-data :as cd]))
 
 (defn suffix
   "Return a random company suffix, like Inc or Group."
   []
-  (rand-nth suffixes))
+  (rand-nth cd/suffixes))
 
 (defn- phrase [source]
   (join " " (map #(rand-nth %) source)))
@@ -16,12 +15,12 @@
 (defn catch-phrase
   "Return a random company catch phrase."
   []
-  (phrase catch-phrase-words))
+  (phrase cd/catch-phrase-words))
 
 (defn bs
   "Return random company BS goals."
   []
-  (phrase bs-words))
+  (phrase cd/bs-words))
 
 (def ^{:private true} formats
   [#(str (first (fkname/names)) " " (suffix))

--- a/src/faker/lorem.cljc
+++ b/src/faker/lorem.cljc
@@ -1,13 +1,12 @@
 (ns faker.lorem
   "Create fake textual data"
-  (:use
-     [clojure.string :only (join capitalize)]
-     faker.lorem-data))
+  (:require [clojure.string :refer [join capitalize]]
+            [faker.lorem-data :as ld]))
 
 (defn words
   "Lazy sequence of random latin words"
   []
-  (repeatedly #(rand-nth latin-words)))
+  (repeatedly #(rand-nth ld/latin-words)))
 
 (defn sentences
   "Lazy sequence of random latin sentences.

--- a/src/faker/name.cljc
+++ b/src/faker/name.cljc
@@ -1,28 +1,27 @@
 (ns faker.name
   "Create fake data for person names"
-  (:use
-     [clojure.string :only [join]]
-     faker.name-data))
+  (:require [clojure.string :refer [join]]
+            [faker.name-data :as nd]))
 
 (defn first-name
   "Create a fake person first name"
   []
-  (rand-nth first-names))
+  (rand-nth nd/first-names))
 
 (defn last-name
   "Create a fake person last name"
   []
-  (rand-nth last-names))
+  (rand-nth nd/last-names))
 
 (defn prefix
   "Create a fake person prefix, like in Mr., Mrs., etc."
   []
-  (rand-nth prefixes))
+  (rand-nth nd/prefixes))
 
 (defn suffix
   "Create a fake person suffix, like in Jr., Sr., etc."
   []
-  (rand-nth suffixes))
+  (rand-nth nd/suffixes))
 
 (defn- comb [& funs]
   (fn [] (join " " (map #(%) funs))))


### PR DESCRIPTION
As clojurescript does not support `use`, some namespaces cannot be compiled.