### PR TITLE
Make faker.company clojurescript compatible

### DIFF
--- a/src/faker/company.cljc
+++ b/src/faker/company.cljc
@@ -25,7 +25,7 @@
 (def ^{:private true} formats
   [#(str (first (fkname/names)) " " (suffix))
    #(str (fkname/last-name) "-" (fkname/last-name))
-   #(format "%s, %s and %s" (fkname/last-name) (fkname/last-name) (fkname/last-name))])
+   #(str (fkname/last-name) ", " (fkname/last-name) " and " (fkname/last-name))])
 
 
 (defn names []


### PR DESCRIPTION
The current implementation uses `format` function which is not supported in clojurescript. This PR fixes that by replacing `format` by `str`.